### PR TITLE
Fix little typo in configureAPI logger example

### DIFF
--- a/generator/templates/server/configureapi.gotmpl
+++ b/generator/templates/server/configureapi.gotmpl
@@ -53,7 +53,7 @@ func configureAPI(api *{{.Package}}.{{ pascalize .Name }}API) http.Handler {
   // Expected interface func(string, ...interface{})
   //
   // Example:
-  // s.api.Logger = log.Printf
+  // api.Logger = log.Printf
 
   {{ range .Consumes }}{{ if .Implementation }}api.{{ pascalize .Name }}Consumer = {{ .Implementation }}
   {{else}}api.{{ pascalize .Name }}Consumer = runtime.ConsumerFunc(func(r io.Reader, target interface{}) error {


### PR DESCRIPTION
Like : https://github.com/go-swagger/go-swagger/blob/2e3a56a299279b7041791d1a445518f1420431ad/examples/authentication/README.md